### PR TITLE
Add support for individual environment configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ export
 
 all: worker
 
+init_env:
+	mkdir -p $(BUILD)
+	cp -rf $(RESOURCES)/terraforms/environments/$(ENV).tf $(BUILD)/
+
 help:
 	@echo "Usage: make plan_<resource> | <resource> | plan_destroy_<resource> | destroy_<resource>"
 	@echo "Or make show_<resource> | graph"

--- a/resources/terraforms/environments/production.tf
+++ b/resources/terraforms/environments/production.tf
@@ -1,0 +1,17 @@
+variable "instance-type" {
+  default = {
+    bastion = "t2.nano"
+    pki = "t2.nano"
+    etcd = "m3.large"
+    worker = "m3.large"
+  }
+}
+
+variable "instance-count" {
+  default = {
+    bastion = "1"
+    pki = "1"
+    etcd = "3"
+    worker = "3"
+  }
+}

--- a/resources/terraforms/environments/staging.tf
+++ b/resources/terraforms/environments/staging.tf
@@ -1,0 +1,17 @@
+variable "instance-type" {
+  default = {
+    bastion = "t2.nano"
+    pki = "t2.nano"
+    etcd = "m3.large"
+    worker = "m3.large"
+  }
+}
+
+variable "instance-count" {
+  default = {
+    bastion = "1"
+    pki = "1"
+    etcd = "3"
+    worker = "3"
+  }
+}


### PR DESCRIPTION
Allows configuration via `ENV` variable.

As an example, you can now use `var.instance-type[worker]` to get the specific type of instance for a worker.